### PR TITLE
#6 add dummy chapter if no chapter contained in markdown file

### DIFF
--- a/exportManuscript.ps1
+++ b/exportManuscript.ps1
@@ -24,6 +24,11 @@ function Export-Manuscript {
         $markdownContent = $markdownContent -split "`n"
     }
 
+    if (!($markdownContent -contains "<!-- CHAPTER START -->")) {
+        $inChapter = $true
+        $markdownContent += "<!-- CHAPTER END -->"
+    }
+
     # switch -File ($markdownFile) {
     switch ($markdownContent) {
 


### PR DESCRIPTION
This seems to fix the manifest creation if no chapter comments are contained in the markdown file. basically it makes the whole document get wrapped inside a "wrapper chapter" so to speak. 

\cc #6 